### PR TITLE
feat: rework oneOf error output (#48)

### DIFF
--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -163,16 +163,14 @@ exports[`Validation should fail validation for anyOf 1`] = `
    Details:
     * configuration.anyOfKeyword should be an object:
       object { foo?, … }
-    * configuration.anyOfKeyword should be a non-empty string.
-      -> An entry point without name. The string is resolved to a module which is loaded upon startup.
-    * configuration.anyOfKeyword should be an array:
-      [non-empty string, ...] (should not have fewer than 1 item, should not have duplicate items)
-      -> A non-empty array of non-empty strings
     * configuration.anyOfKeyword should be one of these:
-      [non-empty string, ...] (should not have fewer than 1 item, should not have duplicate items)
-      -> An entry point without name. All modules are loaded upon startup. The last one is exported.
-    * configuration.anyOfKeyword should be one of these:
-      non-empty string | [non-empty string, ...] (should not have fewer than 1 item, should not have duplicate items)"
+      non-empty string | [non-empty string, ...] (should not have fewer than 1 item, should not have duplicate items)
+      Details:
+       * configuration.anyOfKeyword should be a non-empty string.
+         -> An entry point without name. The string is resolved to a module which is loaded upon startup.
+       * configuration.anyOfKeyword should be an array:
+         [non-empty string, ...] (should not have fewer than 1 item, should not have duplicate items)
+         -> A non-empty array of non-empty strings"
 `;
 
 exports[`Validation should fail validation for array #1 1`] = `
@@ -905,8 +903,6 @@ exports[`Validation should fail validation for module 1`] = `
       [RegExp | non-empty string | function | [(recursive), ...] | object { and?, exclude?, include?, not?, or?, test? }, ...]
     * configuration.module.rules[0].compiler should be an object:
       object { and?, exclude?, include?, not?, or?, test? }
-    * configuration.module.rules[0].compiler should be one of these:
-      RegExp | non-empty string | function | [(recursive), ...] | object { and?, exclude?, include?, not?, or?, test? }
     * configuration.module.rules[0].compiler should be an array:
       [RegExp | non-empty string | function | [(recursive), ...] | object { and?, exclude?, include?, not?, or?, test? }, ...]"
 `;
@@ -1143,23 +1139,48 @@ exports[`Validation should fail validation for one const 1`] = `
  - configuration.oneConst should be equal to constant [\\"foo\\"]"
 `;
 
-exports[`Validation should fail validation for oneOf 1`] = `
+exports[`Validation should fail validation for oneOf #1 1`] = `
 "Invalid configuration object. Object has been initialised using a configuration object that does not match the API schema.
  - configuration.entry should be one of these:
    function | object { <key>: non-empty string | [non-empty string, ...] (should not have fewer than 1 item, should not have duplicate items) } (should not have fewer than 1 property) | non-empty string | [non-empty string, ...] (should not have fewer than 1 item, should not have duplicate items)
    -> The entry point(s) of the compilation.
    Details:
-    * configuration.entry['foo'] should be a non-empty string.
-      -> The string is resolved to a module which is loaded upon startup.
-    * configuration.entry['foo'] should be an array:
-      [non-empty string, ...] (should not have fewer than 1 item, should not have duplicate items)
-      -> A non-empty array of non-empty strings
-    * configuration.entry['foo'] should be one of these:
-      [non-empty string, ...] (should not have fewer than 1 item, should not have duplicate items)
-      -> All modules are loaded upon startup. The last one is exported.
     * configuration.entry['foo'] should be one of these:
       non-empty string | [non-empty string, ...] (should not have fewer than 1 item, should not have duplicate items)
-      -> An entry point with name"
+      -> An entry point with name
+      Details:
+       * configuration.entry['foo'] should be a non-empty string.
+         -> The string is resolved to a module which is loaded upon startup.
+       * configuration.entry['foo'] should be an array:
+         [non-empty string, ...] (should not have fewer than 1 item, should not have duplicate items)
+         -> A non-empty array of non-empty strings"
+`;
+
+exports[`Validation should fail validation for oneOf #2 1`] = `
+"Invalid configuration object. Object has been initialised using a configuration object that does not match the API schema.
+ - configuration.optimization.runtimeChunk should be one of these:
+   boolean | \\"single\\" | \\"multiple\\" | object { name? }
+   -> Create an additional chunk which contains only the webpack runtime and chunk hash maps
+   Details:
+    * configuration.optimization.runtimeChunk.name should be one of these:
+      string | function
+      -> The name or name factory for the runtime chunks
+      Details:
+       * configuration.optimization.runtimeChunk.name should be a string.
+       * configuration.optimization.runtimeChunk.name should be an instance of function."
+`;
+
+exports[`Validation should fail validation for oneOf #3 1`] = `
+"Invalid configuration object. Object has been initialised using a configuration object that does not match the API schema.
+ - configuration.optimization.runtimeChunk should be one of these:
+   boolean | \\"single\\" | \\"multiple\\" | object { name? }
+   -> Create an additional chunk which contains only the webpack runtime and chunk hash maps
+   Details:
+    * configuration.optimization.runtimeChunk should be a boolean.
+    * configuration.optimization.runtimeChunk should be one of these:
+      \\"single\\" | \\"multiple\\"
+    * configuration.optimization.runtimeChunk should be an object:
+      object { name? }"
 `;
 
 exports[`Validation should fail validation for oneOf with description 1`] = `

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -212,6 +212,14 @@ describe('Validation', () => {
     nonEmptyObject2: { foo: 'test' },
   });
 
+  createSuccessTestCase('oneOf', {
+    optimization: {
+      runtimeChunk: {
+        name: 'fef',
+      },
+    },
+  });
+
   // The "name" option
   createFailedTestCase(
     'webpack name',
@@ -781,9 +789,31 @@ describe('Validation', () => {
   );
 
   createFailedTestCase(
-    'oneOf',
+    'oneOf #1',
     {
       entry: { foo: () => [] },
+    },
+    (msg) => expect(msg).toMatchSnapshot()
+  );
+
+  createFailedTestCase(
+    'oneOf #2',
+    {
+      optimization: {
+        runtimeChunk: {
+          name: /fef/,
+        },
+      },
+    },
+    (msg) => expect(msg).toMatchSnapshot()
+  );
+
+  createFailedTestCase(
+    'oneOf #3',
+    {
+      optimization: {
+        runtimeChunk: (name) => name,
+      },
     },
     (msg) => expect(msg).toMatchSnapshot()
   );


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

closes #48 

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->
no

### Additional Info

Now all `oneOf`/`anyOf` that contains exactly one child in schema, i.e.
```
{
    anyOf: [{ type: string }] 
}
```
will be skipped in favor of their child, so it won't produce additional output:
```
Details: ...
   string
   Details: <children info>
```

If this behavior need to be fixed I can change it