### PR TITLE
fix: remove esModuleInterop from tsconfig (#110)

### DIFF
--- a/declarations/validate.d.ts
+++ b/declarations/validate.d.ts
@@ -2,7 +2,7 @@ export default validate;
 export type JSONSchema4 = import('json-schema').JSONSchema4;
 export type JSONSchema6 = import('json-schema').JSONSchema6;
 export type JSONSchema7 = import('json-schema').JSONSchema7;
-export type ErrorObject = Ajv.ErrorObject;
+export type ErrorObject = import('ajv').ErrorObject;
 export type Extend = {
   formatMinimum?: number | undefined;
   formatMaximum?: number | undefined;
@@ -13,8 +13,8 @@ export type Schema =
   | (import('json-schema').JSONSchema4 & Extend)
   | (import('json-schema').JSONSchema6 & Extend)
   | (import('json-schema').JSONSchema7 & Extend);
-export type SchemaUtilErrorObject = Ajv.ErrorObject & {
-  children?: Ajv.ErrorObject[] | undefined;
+export type SchemaUtilErrorObject = import('ajv').ErrorObject & {
+  children?: import('ajv').ErrorObject[] | undefined;
 };
 export type PostFormatter = (
   formattedError: string,
@@ -40,5 +40,4 @@ declare namespace validate {
   export { ValidationError };
   export { ValidationError as ValidateError };
 }
-import Ajv from 'ajv';
 import ValidationError from './ValidationError';

--- a/src/validate.js
+++ b/src/validate.js
@@ -1,9 +1,10 @@
-import Ajv from 'ajv';
-import ajvKeywords from 'ajv-keywords';
-
 import addAbsolutePathKeyword from './keywords/absolutePath';
 
 import ValidationError from './ValidationError';
+
+// Use CommonJS require for ajv libs so TypeScript consumers aren't locked into esModuleInterop (see #110).
+const Ajv = require('ajv');
+const ajvKeywords = require('ajv-keywords');
 
 /** @typedef {import("json-schema").JSONSchema4} JSONSchema4 */
 /** @typedef {import("json-schema").JSONSchema6} JSONSchema6 */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "checkJs": true,
     "strict": true,
     "types": ["node"],
-    "esModuleInterop": true,
     "resolveJsonModule": true
   },
   "include": ["./types/**/*", "./src/**/*"]


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

#110 

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

none

### Additional Info

allows direct and transitive consumers of this dependency to no longer be required to add `esModuleInterop` to their tsconfig.json