### PR TITLE
feat: added API to disable and enable validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,36 @@ class Plugin {
 export default Plugin;
 ```
 
+### Allow to disable and enable validation (the `validate` function do nothing)
+
+This can be useful when you don't want to do validation for `production` builds.
+
+```js
+import { disableValidation, enableValidation, validate } from "schema-utils";
+
+// Disable validation
+disableValidation();
+// Do nothing
+validate(schema, options);
+
+// Enable validation
+enableValidation();
+// Will throw an error if schema is not valid
+validate(schema, options);
+
+// Allow to undestand do you need validation or not
+const need = needValidate();
+
+console.log(need);
+```
+
+Also you can enable/disable validation using the `process.env.SKIP_VALIDATION` env variable.
+
+Supported values (case insensitive):
+
+- `yes`/`y`/`true`/`1`/`on`
+- `no`/`n`/`false`/`0`/`off`
+
 ## Contributing
 
 Please take a moment to read our contributing guidelines if you haven't yet done so.

--- a/declarations/index.d.ts
+++ b/declarations/index.d.ts
@@ -1,3 +1,12 @@
 import { validate } from "./validate";
 import { ValidationError } from "./validate";
-export { validate, ValidationError };
+import { enableValidation } from "./validate";
+import { disableValidation } from "./validate";
+import { needValidate } from "./validate";
+export {
+  validate,
+  ValidationError,
+  enableValidation,
+  disableValidation,
+  needValidate,
+};

--- a/declarations/validate.d.ts
+++ b/declarations/validate.d.ts
@@ -34,5 +34,8 @@ export function validate(
   options: Array<object> | object,
   configuration?: ValidationErrorConfiguration | undefined
 ): void;
+export function enableValidation(): void;
+export function disableValidation(): void;
+export function needValidate(): boolean;
 import ValidationError from "./ValidationError";
 export { ValidationError };

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,15 @@
-const { validate, ValidationError } = require("./validate");
+const {
+  validate,
+  ValidationError,
+  enableValidation,
+  disableValidation,
+  needValidate,
+} = require("./validate");
 
-module.exports = { validate, ValidationError };
+module.exports = {
+  validate,
+  ValidationError,
+  enableValidation,
+  disableValidation,
+  needValidate,
+};

--- a/src/validate.js
+++ b/src/validate.js
@@ -55,7 +55,7 @@ const getAjv = memoize(() => {
 
 /** @typedef {(JSONSchema4 | JSONSchema6 | JSONSchema7) & Extend} Schema */
 
-/** @typedef {ErrorObject & { children?: Array<ErrorObject>}} SchemaUtilErrorObject */
+/** @typedef {ErrorObject & { children?: Array<ErrorObject> }} SchemaUtilErrorObject */
 
 /**
  * @callback PostFormatter
@@ -87,6 +87,51 @@ function applyPrefix(error, idx) {
   return error;
 }
 
+let skipValidation = false;
+
+// We use `process.env.SKIP_VALIDATION` because you can have multiple `schema-utils` with different version,
+// so we want to disable it globally, `process.env` doesn't supported by browsers, so we have the local `skipValidation` variables
+
+// Enable validation
+function enableValidation() {
+  skipValidation = false;
+
+  // Disable validation for any versions
+  if (process && process.env) {
+    process.env.SKIP_VALIDATION = "n";
+  }
+}
+
+// Disable validation
+function disableValidation() {
+  skipValidation = true;
+
+  if (process && process.env) {
+    process.env.SKIP_VALIDATION = "y";
+  }
+}
+
+// Check if we need to confirm
+function needValidate() {
+  if (skipValidation) {
+    return false;
+  }
+
+  if (process && process.env && process.env.SKIP_VALIDATION) {
+    const value = process.env.SKIP_VALIDATION.trim();
+
+    if (/^(?:y|yes|true|1|on)$/i.test(value)) {
+      return false;
+    }
+
+    if (/^(?:n|no|false|0|off)$/i.test(value)) {
+      return true;
+    }
+  }
+
+  return true;
+}
+
 /**
  * @param {Schema} schema
  * @param {Array<object> | object} options
@@ -94,6 +139,10 @@ function applyPrefix(error, idx) {
  * @returns {void}
  */
 function validate(schema, options, configuration) {
+  if (!needValidate()) {
+    return;
+  }
+
   let errors = [];
 
   if (Array.isArray(options)) {
@@ -165,4 +214,10 @@ function filterErrors(errors) {
   return newErrors;
 }
 
-export { validate, ValidationError };
+export {
+  validate,
+  enableValidation,
+  disableValidation,
+  needValidate,
+  ValidationError,
+};

--- a/test/__snapshots__/api.test.js.snap
+++ b/test/__snapshots__/api.test.js.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`api should allow to enable validation using "process.env.SKIP_VALIDATION" #2 1`] = `
+"Invalid options object. NAME has been initialized using an options object that does not match the API schema.
+ - options has an unknown property 'foo'. These properties are valid:
+   object { name? }"
+`;
+
+exports[`api should allow to enable validation using "process.env.SKIP_VALIDATION" 1`] = `
+"Invalid options object. NAME has been initialized using an options object that does not match the API schema.
+ - options has an unknown property 'foo'. These properties are valid:
+   object { name? }"
+`;
+
+exports[`api should allow to enable validation using API 1`] = `
+"Invalid options object. NAME has been initialized using an options object that does not match the API schema.
+ - options has an unknown property 'foo'. These properties are valid:
+   object { name? }"
+`;
+
 exports[`api should get configuration from schema 1`] = `
 "Invalid options object. CSS Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'foo'. These properties are valid:


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

Allow to enable/disable validation using:
- API
- `process.env.SKIP_VALIDATION`

### Breaking Changes

No

### Additional Info

We use local and `process.env.SKIP_VALIDATION` variables to disable it to support globally disabling, because you can have multiple different versions