### PR TITLE
feat: allow file:// protocol prefix in absolute paths

### DIFF
--- a/src/keywords/absolutePath.js
+++ b/src/keywords/absolutePath.js
@@ -70,11 +70,12 @@ function addAbsolutePathKeyword(ajv) {
           passes = false;
         }
 
+        // (?:file:\/\/)? - optional file:// protocol prefix
         // ?:[A-Za-z]:\\ - Windows absolute path
         // \\\\ - Windows network absolute path
         // \/ - Unix-like OS absolute path
         const isCorrectAbsolutePath =
-          schema === /^(?:[A-Za-z]:(\\|\/)|\\\\|\/)/.test(data);
+          schema === /^(?:file:\/\/)?(?:[A-Za-z]:(\\|\/)|\\\\|\/)/.test(data);
 
         if (!isCorrectAbsolutePath) {
           callback.errors = [getErrorFor(schema, parentSchema, data)];

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -325,6 +325,14 @@ describe("validation", () => {
     testAbsolutePath: "//server/directory/deep/tree",
   });
 
+  createSuccessTestCase("absolutePath #6", {
+    testAbsolutePath: "file:///Users/username/directory/deep/tree",
+  });
+
+  createSuccessTestCase("absolutePath #7", {
+    testAbsolutePath: "file:///C:/directory/deep/tree",
+  });
+
   createSuccessTestCase("$data", {
     dollarData: {
       smaller: 5,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Fixes #209 

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

This allows an optional `file://` protocol prefix for absolute paths, such as those returned by `import.meta.resolve()`.

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

Yes.

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

Not that I know of.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

I couldn't find docs for the absolute path functions, so I didn't add any.

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
