### PR TITLE
ci: skip lifecycle scripts when installing on legacy Node.js versions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -76,9 +76,11 @@ jobs:
           architecture: ${{ steps.calculate_architecture.outputs.result }}
           cache: "npm"
       - name: Install dependencies
+        # Legacy versions do not generate types, so skip scripts that invoke `prepare` and explicitly run the code build without generating types
         run: |
-          npm i -D typescript@4 del-cli@^3
-          npm i --ignore-engines
+          npm i -D typescript@4 del-cli@^3 --ignore-scripts
+          npm i --ignore-engines --ignore-scripts
+          npm run build:code
         if: matrix.node-version == '10.x' || matrix.node-version == '12.x' || matrix.node-version == '14.x' || matrix.node-version == '16.x' || matrix.node-version == '18.x'
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Ignores postinstall scripts that invokes `npm run prepare` and explicitly run `npm run build:code` for legacy nodejs versions that doesnt have types.
