### PR TITLE
test: cover collecting a subtree of errors and grouping a nested `anyOf`

### DIFF
--- a/test/filter-errors.test.js
+++ b/test/filter-errors.test.js
@@ -143,6 +143,68 @@ describe("filter errors", () => {
     );
   });
 
+  // `groupChildrenByFirstChild` puts the errors of an inner `anyOf` under it
+  it("should group the children of a nested `anyOf`", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        a: {
+          anyOf: [
+            { anyOf: [{ type: "string" }, { type: "number" }] },
+            { type: "boolean" },
+          ],
+        },
+      },
+    };
+
+    const message = getMessage(schema, { a: {} });
+
+    expect(message).toContain("configuration.a should be one of these:");
+    expect(message).toContain("string | number | boolean");
+    // the inner `anyOf` and its own branches, not a flat list of every branch
+    expect(message).toContain(
+      "configuration.a should be one of these:\n   string | number",
+    );
+  });
+
+  // Enough errors to use the instance path index, with an error that arrives after the errors
+  // nested inside it and so collects a whole subtree at once
+  it("should nest a subtree of errors under a later error covering it", () => {
+    const length = 30;
+    const properties = {};
+
+    for (let i = 0; i < length; i++) {
+      properties[`p${i}`] = { type: "string" };
+    }
+
+    const schema = {
+      type: "object",
+      properties: {
+        a: { anyOf: [{ type: "object", properties }, { type: "string" }] },
+      },
+    };
+
+    const options = { a: {} };
+
+    for (let i = 0; i < length; i++) {
+      options.a[`p${i}`] = 1;
+    }
+
+    const errors = getErrors(schema, options);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].keyword).toBe("anyOf");
+    expect(errors[0].instancePath).toBe("/a");
+
+    const children = errors[0].children.map((error) => error.instancePath);
+
+    // every nested error, in the order it was reported, plus the error for the second branch
+    expect(children).toStrictEqual([
+      ...Array.from({ length }, (_, i) => `/a/p${i}`),
+      "/a",
+    ]);
+  });
+
   // `filterErrors` used to be quadratic in the amount of reported errors, so a large invalid
   // configuration was enough to lock up the process for minutes
   it("should filter a large amount of sibling errors in a reasonable time", () => {


### PR DESCRIPTION
Follow up to #217, which merged before this landed.

`codecov` reported 5 lines of #217 without coverage. Four of them are in the instance path index
that `filterErrors` uses above 24 errors: it was only exercised by errors that share an instance
path or have none in common, so the branch that walks into the children of a node and the comparator
that puts the collected errors back in the order they were reported were never reached.

An error that arrives after the errors nested inside it collects a whole subtree at once and covers
both - a value failing an `anyOf` whose object branch reports an error per property:

```js
{ a: { anyOf: [{ type: "object", properties: { p0: …, p29: … } }, { type: "string" }] } }
```

The second test covers `groupChildrenByFirstChild` putting the errors of an inner `anyOf` under it
rather than listing every branch flat, which is the path `findAllChildren` was changed for in #217.

`src/validate.js` goes from 97.84% to 100% of lines, statements and functions. What is left there is
branch coverage for the guards of environments without `process` or `globalThis`, which cannot be
taken on the Node.js the tests run on.

Tests only, no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wqLmVHkAGBsWQgXknEQCK

---
_Generated by [Claude Code](https://claude.ai/code/session_013wqLmVHkAGBsWQgXknEQCK)_