### PR TITLE
feat: allow `file://` protocol prefix in absolute paths

### DIFF
--- a/.changeset/olive-files-resolve.md
+++ b/.changeset/olive-files-resolve.md
@@ -2,6 +2,7 @@
 "schema-utils": minor
 ---
 
+pr: 222
 author: laymonage
 author: alexander-akait
 

--- a/.changeset/olive-files-resolve.md
+++ b/.changeset/olive-files-resolve.md
@@ -1,0 +1,8 @@
+---
+"schema-utils": minor
+---
+
+author: laymonage
+author: alexander-akait
+
+The `absolutePath` keyword accepts an optional `file://` prefix now, so a path from `import.meta.resolve()` can be passed to an option that takes an absolute path. Options that take a relative path reject such a value instead, they used to accept it.

--- a/src/keywords/absolutePath.js
+++ b/src/keywords/absolutePath.js
@@ -70,11 +70,12 @@ function addAbsolutePathKeyword(ajv) {
           passes = false;
         }
 
+        // (?:file:\/\/)? - optional file:// protocol prefix
         // ?:[A-Za-z]:\\ - Windows absolute path
         // \\\\ - Windows network absolute path
         // \/ - Unix-like OS absolute path
         const isCorrectAbsolutePath =
-          schema === /^(?:[A-Za-z]:(\\|\/)|\\\\|\/)/.test(data);
+          schema === /^(?:file:\/\/)?(?:[A-Za-z]:(\\|\/)|\\\\|\/)/.test(data);
 
         if (!isCorrectAbsolutePath) {
           callback.errors = [getErrorFor(schema, parentSchema, data)];

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3061,6 +3061,127 @@ describe("validation", () => {
     webpackSchema,
   );
 
+  // `import.meta.resolve()` returns a `file://` URL, so every option of webpack's own schema that
+  // takes an absolute path has to accept one - these are all of them
+  const WEBPACK_FILE_URL = "file:///directory/deep/tree";
+
+  /** @type {Record<string, Record<string, EXPECTED_ANY>>} */
+  const webpackAbsolutePathOptions = {
+    "cache.cacheDirectory": {
+      cache: { type: "filesystem", cacheDirectory: WEBPACK_FILE_URL },
+    },
+    "cache.cacheLocation": {
+      cache: { type: "filesystem", cacheLocation: WEBPACK_FILE_URL },
+    },
+    "cache.immutablePaths": {
+      cache: { type: "filesystem", immutablePaths: [WEBPACK_FILE_URL] },
+    },
+    "cache.managedPaths": {
+      cache: { type: "filesystem", managedPaths: [WEBPACK_FILE_URL] },
+    },
+    context: { context: WEBPACK_FILE_URL },
+    "dotenv.dir": { dotenv: { dir: WEBPACK_FILE_URL } },
+    "experiments.buildHttp.cacheLocation": {
+      experiments: {
+        buildHttp: { allowedUris: [], cacheLocation: WEBPACK_FILE_URL },
+      },
+    },
+    "experiments.buildHttp.lockfileLocation": {
+      experiments: {
+        buildHttp: { allowedUris: [], lockfileLocation: WEBPACK_FILE_URL },
+      },
+    },
+    "module.defaultRules.exclude": {
+      module: { defaultRules: [{ exclude: WEBPACK_FILE_URL }] },
+    },
+    "module.defaultRules.include": {
+      module: { defaultRules: [{ include: WEBPACK_FILE_URL }] },
+    },
+    "module.defaultRules.issuer": {
+      module: { defaultRules: [{ issuer: WEBPACK_FILE_URL }] },
+    },
+    "module.defaultRules.realResource": {
+      module: { defaultRules: [{ realResource: WEBPACK_FILE_URL }] },
+    },
+    "module.defaultRules.resolve.restrictions": {
+      module: {
+        defaultRules: [{ resolve: { restrictions: [WEBPACK_FILE_URL] } }],
+      },
+    },
+    "module.defaultRules.resource": {
+      module: { defaultRules: [{ resource: WEBPACK_FILE_URL }] },
+    },
+    "module.defaultRules.test": {
+      module: { defaultRules: [{ test: WEBPACK_FILE_URL }] },
+    },
+    "module.noParse": { module: { noParse: WEBPACK_FILE_URL } },
+    "module.noParse[]": { module: { noParse: [WEBPACK_FILE_URL] } },
+    "module.rules.exclude": {
+      module: { rules: [{ exclude: WEBPACK_FILE_URL }] },
+    },
+    "module.rules.include": {
+      module: { rules: [{ include: WEBPACK_FILE_URL }] },
+    },
+    "module.rules.issuer": {
+      module: { rules: [{ issuer: WEBPACK_FILE_URL }] },
+    },
+    "module.rules.realResource": {
+      module: { rules: [{ realResource: WEBPACK_FILE_URL }] },
+    },
+    "module.rules.resolve.restrictions": {
+      module: { rules: [{ resolve: { restrictions: [WEBPACK_FILE_URL] } }] },
+    },
+    "module.rules.resource": {
+      module: { rules: [{ resource: WEBPACK_FILE_URL }] },
+    },
+    "module.rules.test": { module: { rules: [{ test: WEBPACK_FILE_URL }] } },
+    "output.path": { output: { path: WEBPACK_FILE_URL } },
+    recordsInputPath: { recordsInputPath: WEBPACK_FILE_URL },
+    recordsOutputPath: { recordsOutputPath: WEBPACK_FILE_URL },
+    recordsPath: { recordsPath: WEBPACK_FILE_URL },
+    "resolve.restrictions": { resolve: { restrictions: [WEBPACK_FILE_URL] } },
+    "resolveLoader.restrictions": {
+      resolveLoader: { restrictions: [WEBPACK_FILE_URL] },
+    },
+    "snapshot.immutablePaths": {
+      snapshot: { immutablePaths: [WEBPACK_FILE_URL] },
+    },
+    "snapshot.managedPaths": { snapshot: { managedPaths: [WEBPACK_FILE_URL] } },
+    "snapshot.unmanagedPaths": {
+      snapshot: { unmanagedPaths: [WEBPACK_FILE_URL] },
+    },
+    "stats.context": { stats: { context: WEBPACK_FILE_URL } },
+  };
+
+  for (const [option, config] of Object.entries(webpackAbsolutePathOptions)) {
+    createSuccessTestCase(
+      `\`file://\` for the webpack option \`${option}\``,
+      config,
+      {},
+      webpackSchema,
+    );
+  }
+
+  // The prefix must not turn an option that wants a relative path into an absolute one
+  it.each([
+    ["output.filename", { output: { filename: WEBPACK_FILE_URL } }],
+    [
+      "output.sourceMapFilename",
+      { output: { sourceMapFilename: WEBPACK_FILE_URL } },
+    ],
+    [
+      "output.assetModuleFilename",
+      { output: { assetModuleFilename: WEBPACK_FILE_URL } },
+    ],
+  ])(
+    "should fail validation for `file://` for the relative webpack option `%s`",
+    (option, config) => {
+      expect(() => validate(webpackSchema, config)).toThrow(
+        /is an absolute path!/,
+      );
+    },
+  );
+
   createFailedTestCase(
     "formatExclusiveMaximum #1",
     {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -325,6 +325,14 @@ describe("validation", () => {
     testAbsolutePath: "//server/directory/deep/tree",
   });
 
+  createSuccessTestCase("absolutePath #6", {
+    testAbsolutePath: "file:///Users/username/directory/deep/tree",
+  });
+
+  createSuccessTestCase("absolutePath #7", {
+    testAbsolutePath: "file:///C:/directory/deep/tree",
+  });
+
   createSuccessTestCase("$data", {
     dollarData: {
       smaller: 5,


### PR DESCRIPTION
Recreates #210 by @laymonage, rebased on `main`, with the original commit kept as a co-author. Fixes #209.

**Summary**

`import.meta.resolve()` returns a `file://` URL, so passing one to an option that takes an absolute path failed validation. The `absolutePath` keyword accepts an optional `file://` prefix now:

```js
- schema === /^(?:[A-Za-z]:(\\|\/)|\\\\|\/)/.test(data);
+ schema === /^(?:file:\/\/)?(?:[A-Za-z]:(\\|\/)|\\\\|\/)/.test(data);
```

**What kind of change does this PR introduce?**

A feature, plus test coverage for it.

**Did you add tests for your changes?**

Yes. Beyond the two cases from the original PR, every option of webpack's own schema that takes an absolute path is covered - the point being to verify the support against a real consumer rather than the fixture schema alone.

Walking `webpack/schemas/WebpackOptions.json` from the root and resolving `$ref`s gives 34 reachable options that use `absolutePath: true`, and each one now has a test that a `file://` URL validates for it:

| Area | Options |
| --- | --- |
| Top level | `context`, `recordsPath`, `recordsInputPath`, `recordsOutputPath` |
| `output` | `output.path` |
| `cache` | `cacheDirectory`, `cacheLocation`, `immutablePaths`, `managedPaths` |
| `snapshot` | `immutablePaths`, `managedPaths`, `unmanagedPaths` |
| `module` | `noParse` and `noParse[]`; for both `rules` and `defaultRules`: `test`, `include`, `exclude`, `issuer`, `resource`, `realResource`, `resolve.restrictions` |
| `resolve` | `resolve.restrictions`, `resolveLoader.restrictions` |
| `experiments` | `buildHttp.cacheLocation`, `buildHttp.lockfileLocation` |
| Other | `dotenv.dir`, `stats.context` |

All 34 fail without the change to `absolutePath.js` and pass with it, so they are covering the behaviour rather than passing by accident.

**Does this PR introduce a breaking change?**

One small behaviour change, covered by its own tests: an option that takes a *relative* path (`output.filename`, `output.sourceMapFilename`, `output.assetModuleFilename` and friends, which use `absolutePath: false`) used to accept a `file://` value, because it did not look absolute. Such a value is recognised as absolute now and is rejected for those options, which is what they mean. The changeset is a `minor` and calls it out.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

Nothing - as in the original PR, there are no docs for the absolute path keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wqLmVHkAGBsWQgXknEQCK

---
_Generated by [Claude Code](https://claude.ai/code/session_013wqLmVHkAGBsWQgXknEQCK)_