### PR TITLE
feat: read the `format` keyword as part of the type

### DIFF
--- a/.changeset/humanize-format.md
+++ b/.changeset/humanize-format.md
@@ -1,0 +1,5 @@
+---
+"schema-utils": patch
+---
+
+read the `format` keyword as part of the type, i.e. `should be a date string` instead of `should be a string (should match format "date")`

--- a/declarations/util/humanize.d.ts
+++ b/declarations/util/humanize.d.ts
@@ -1,0 +1,2 @@
+declare function _exports(str: string): string;
+export = _exports;

--- a/src/util/hints.js
+++ b/src/util/hints.js
@@ -1,4 +1,10 @@
 const Range = require("./Range");
+const humanize = require("./humanize");
+
+const STRING_TYPE_REGEXP = /string$/;
+// A format that is a name, so it can be read as words. A format is any string,
+// including a pattern like `[0-9]*`, and such a one is left to a hint
+const FORMAT_NAME_REGEXP = /^[A-Za-z][A-Za-z\d]*(?:[-_][A-Za-z\d]+)*$/;
 
 /** @typedef {import("../validate").Schema} Schema */
 
@@ -50,6 +56,7 @@ module.exports.numberHints = function numberHints(schema, logic) {
 module.exports.stringHints = function stringHints(schema, logic) {
   const hints = [];
   let type = "string";
+  let formatName = "";
   const currentSchema = { ...schema };
 
   if (!logic) {
@@ -99,11 +106,17 @@ module.exports.stringHints = function stringHints(schema, logic) {
   }
 
   if (currentSchema.format) {
-    hints.push(
-      `should${logic ? "" : " not"} match format ${JSON.stringify(
-        currentSchema.format,
-      )}`,
-    );
+    if (logic && FORMAT_NAME_REGEXP.test(currentSchema.format)) {
+      // The format names the string, `should be a date string` reads better than
+      // `should be a string (should match format "date")`
+      formatName = humanize(currentSchema.format);
+    } else {
+      hints.push(
+        `should${logic ? "" : " not"} match format ${JSON.stringify(
+          currentSchema.format,
+        )}`,
+      );
+    }
   }
 
   if (currentSchema.formatMinimum) {
@@ -122,5 +135,12 @@ module.exports.stringHints = function stringHints(schema, logic) {
     );
   }
 
-  return [type, ...hints];
+  // Every type here ends with `string`, the format names the string itself, so it
+  // goes next to that word - `non-empty email string`, not `email non-empty string`
+  return [
+    formatName
+      ? type.replace(STRING_TYPE_REGEXP, `${formatName} string`)
+      : type,
+    ...hints,
+  ];
 };

--- a/src/util/humanize.js
+++ b/src/util/humanize.js
@@ -1,0 +1,29 @@
+const CAMEL_CASE_REGEXP = /([^A-Z])([A-Z])/g;
+const LEADING_UNDERSCORE_REGEXP = /^_/;
+
+/**
+ * Turns the name of a format into words, so `dash-case`, `snake_case`,
+ * `camelCase` and `PascalCase` all read as `dash case`, `snake case`, and so on.
+ * @param {string} str provided string
+ * @returns {string} the string as human readable words
+ */
+module.exports = function humanize(str) {
+  if (str.length < 2) {
+    return str;
+  }
+
+  if (str.includes("-")) {
+    return str.split("-").join(" ").toLowerCase();
+  }
+
+  // A leading underscore is not a word boundary, `_12Integers` is `12 integers`
+  const withoutLeadingUnderscore = str.replace(LEADING_UNDERSCORE_REGEXP, "");
+
+  if (withoutLeadingUnderscore.includes("_")) {
+    return withoutLeadingUnderscore.split("_").join(" ").toLowerCase();
+  }
+
+  return withoutLeadingUnderscore
+    .replace(CAMEL_CASE_REGEXP, "$1 $2")
+    .toLowerCase();
+};

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -733,7 +733,7 @@ exports[`validation should fail validation for format, formatMaximum and formatE
 
 exports[`validation should fail validation for format, formatMaximum and formatExclusiveMaximum 1`] = `
 "Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
- - configuration.strictFormat should be a string (should match format "date", should be < "2016-02-06")."
+ - configuration.strictFormat should be a date string (should be < "2016-02-06")."
 `;
 
 exports[`validation should fail validation for format, formatMinimum and formatExclusiveMinimum #2 1`] = `
@@ -743,7 +743,7 @@ exports[`validation should fail validation for format, formatMinimum and formatE
 
 exports[`validation should fail validation for format, formatMinimum and formatExclusiveMinimum 1`] = `
 "Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
- - configuration.strictFormat2 should be a string (should match format "date", should be > "2016-02-06")."
+ - configuration.strictFormat2 should be a date string (should be > "2016-02-06")."
 `;
 
 exports[`validation should fail validation for formatExclusiveMaximum #1 1`] = `

--- a/test/hints.test.js
+++ b/test/hints.test.js
@@ -31,12 +31,22 @@ const testCases = [
     ['should not match pattern "phone"'],
   ],
   [
+    { format: "date-time" },
+    ["date time string"],
+    ['should not match format "date-time"'],
+  ],
+  [
+    { format: "email", minLength: 1 },
+    ["non-empty email string"],
+    ['should not match format "email"'],
+  ],
+  [
     {
       format: "date",
       formatMaximum: "01.01.2022",
       formatExclusiveMaximum: "01.01.2022",
     },
-    ['should match format "date"', 'should be < "01.01.2022"'],
+    ["date string", 'should be < "01.01.2022"'],
     ['should not match format "date"', 'should be >= "01.01.2022"'],
   ],
 ];

--- a/test/humanize.test.js
+++ b/test/humanize.test.js
@@ -1,0 +1,23 @@
+const humanize = require("../src/util/humanize");
+
+const words = [
+  ["dash-case", "dash case"],
+  ["_snake_case", "snake case"],
+  ["snake-case", "snake case"],
+  ["PascalCase", "pascal case"],
+  ["_12Integers", "12 integers"],
+  ["awesomeStringFormat13", "awesome string format13"],
+  ["camelCase", "camel case"],
+  ["date-time", "date time"],
+  ["email", "email"],
+  ["a", "a"],
+  ["", ""],
+];
+
+describe("humanize", () => {
+  for (const [provided, expected] of words) {
+    it(JSON.stringify(provided), () => {
+      expect(humanize(provided)).toBe(expected);
+    });
+  }
+});


### PR DESCRIPTION
Salvages what is still useful from #59 and #68, both of which this supersedes.

### What is left in those two

**#59 (`feat: format object properties with types`, issue #42)** — the feature it adds landed in #224, so nothing here comes from it. Worth recording why it is not just rebased: it names the property type from a bare `schema.properties[x].type`, which prints `foo: string,number` for a union and nothing at all for a property described by `anyOf`/`$ref`/`const`. #224 formats the type through `formatInnerSchema` and drops it when it is composite or when the shape stops fitting on a line. The two open questions in its thread stay open — breaking long objects over lines (also raised in https://github.com/webpack/schema-utils/issues/42#issuecomment-536067241) and sorting properties alphabetically.

**#68 (`feat: humanize format`, issue #66)** — two separate things. The `absolutePath`-as-a-format half is breaking and vankop flagged it for discussion; #223 has since covered that reporting as a keyword, so it is dropped. The other half is not on `main` and is what this PR takes.

### The change

A `format` was reported as a hint sitting next to the constraints of the string:

```
configuration.strictFormat should be a string (should match format "date", should be < "2016-02-06").
```

It names the string, so it now reads as part of the type:

```
configuration.strictFormat should be a date string (should be < "2016-02-06").
```

`src/util/humanize.js` turns the name into words, so `date-time`, `snake_case`, `PascalCase` and `camelCase` formats all read as words.

Two cases #68 did not cover, both of which the existing fixtures caught:

- **A format is any string, not only a name.** The test schema has `format: "[0-9]*"`, which humanizing renders as `[0 9]* string`. A format that is not a name is left as a hint.
- **A negated format** has no type to be part of — `should not match format "date"` stays a hint.

The format name goes next to the word it names rather than in front of the whole type, so a `format: "email"` with `minLength: 1` is `a non-empty email string`, not `an email non-empty string`.

### Tests

`test/humanize.test.js` carries over vankop's word list from #68, plus the empty/one-character and `date-time` cases. `test/hints.test.js` gains the composition and negation cases; its existing `[0-9]*` case covers the not-a-name guard. Two snapshots move, both to the shorter message above.

`npm test` (503 tests, 338 snapshots), `npm run lint` and `npm run build` all pass.

Co-authored with @vankop, whose commit in #68 this is taken from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wqLmVHkAGBsWQgXknEQCK

---
_Generated by [Claude Code](https://claude.ai/code/session_013wqLmVHkAGBsWQgXknEQCK)_